### PR TITLE
Haskell mouse/[AD-502] getstate function fails if there is an empty db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.stack-work
 dist/**
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,85 @@
-language: haskell
-env:
- #- GHCVER=7.4.2 CABALVER=1.18
- - GHCVER=7.6.3 CABALVER=1.18
- - GHCVER=7.8.4 CABALVER=1.18
- - GHCVER=7.10.1 CABALVER=1.22
- - GHCVER=7.10.2 CABALVER=1.22
- - GHCVER=head  CABALVER=head
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
 
 matrix:
-  allow_failures:
- #  - env: GHCVER=7.10.1 CABALVER=1.22
-   - env: GHCVER=head  CABALVER=head
+  include:
+    - env: CABALVER=1.16 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
 before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
- - cabal --version
- - cabal install happy alex
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
- - travis_retry cabal update
- - cabal install --only-dependencies --enable-tests
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
 script:
- - cabal configure --enable-tests
- - cabal build
- # - cabal test
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
+    - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.14.2
+======
+
+ - createCheckpoint now cuts a new events file (bug #74)
+
 0.14.1
 ======
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.14.1
+======
+
+ - fix bug in archiveLog that resulted in logs being moved prematurely (bug #22)
+ - tweaks for GHC 8.0.x, template-haskell 2.11.x
+ - fix compilation of benchmarks
+
 0.14.0
 ======
 

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -2,7 +2,7 @@ Name:                acid-state
 Version:             0.14.2
 Synopsis:            Add ACID guarantees to any serializable Haskell data structure.
 Description:         Use regular Haskell data structures as your database and get stronger ACID guarantees than most RDBMS offer.
-Homepage:            http://acid-state.seize.it/
+Homepage:            https://github.com/acid-state/acid-state
 License:             PublicDomain
 Author:              David Himmelstrup
 Maintainer:          Lemmih <lemmih@gmail.com>

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -1,5 +1,5 @@
 Name:                acid-state
-Version:             0.14.1
+Version:             0.14.2
 Synopsis:            Add ACID guarantees to any serializable Haskell data structure.
 Description:         Use regular Haskell data structures as your database and get stronger ACID guarantees than most RDBMS offer.
 Homepage:            http://acid-state.seize.it/

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -10,6 +10,7 @@ Maintainer:          Lemmih <lemmih@gmail.com>
 Category:            Database
 Build-type:          Simple
 Cabal-version:       >=1.10
+tested-with:         GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1
 Extra-source-files:
         CHANGELOG.md
         examples/*.hs

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -1,5 +1,5 @@
 Name:                acid-state
-Version:             0.14.0
+Version:             0.14.1
 Synopsis:            Add ACID guarantees to any serializable Haskell data structure.
 Description:         Use regular Haskell data structures as your database and get stronger ACID guarantees than most RDBMS offer.
 Homepage:            http://acid-state.seize.it/

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -30,6 +30,10 @@ Library
                        Data.Acid.Log, Data.Acid.CRC,
                        Data.Acid.Abstract, Data.Acid.Core
 
+                       Serokell.AcidState.ExtendedState
+                       Serokell.AcidState.Instances
+                       Serokell.AcidState.Util
+
   Other-modules:       Data.Acid.Archive,
                        Paths_acid_state,
                        Data.Acid.TemplateHaskell, Data.Acid.Common, FileIO
@@ -39,15 +43,20 @@ Library
                        bytestring >= 0.10.2,
                        cereal >= 0.4.1.0,
                        containers,
-                       extensible-exceptions,
-                       safecopy >= 0.6,
-                       stm >= 2.4,
                        directory,
                        filepath,
+                       exceptions,
+                       extensible-exceptions,
+                       extra,
+                       hashable,
                        mtl,
                        network,
+                       safecopy >= 0.6,
+                       stm >= 2.4,
                        template-haskell,
-                       th-expand-syns >= 0.4.1 && < 0.5
+                       th-expand-syns >= 0.4.1 && < 0.5,
+                       time-units,
+                       unordered-containers
 
   if os(windows)
      Build-depends:       Win32

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -44,6 +44,7 @@ Library
                        cereal >= 0.4.1.0,
                        containers,
                        directory,
+                       filelock,
                        filepath,
                        exceptions,
                        extensible-exceptions,

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -47,7 +47,7 @@ Library
                        mtl,
                        network,
                        template-haskell,
-                       th-expand-syns
+                       th-expand-syns >= 0.4.1 && < 0.5
 
   if os(windows)
      Build-depends:       Win32

--- a/acid-state.cabal
+++ b/acid-state.cabal
@@ -46,7 +46,8 @@ Library
                        filepath,
                        mtl,
                        network,
-                       template-haskell
+                       template-haskell,
+                       th-expand-syns
 
   if os(windows)
      Build-depends:       Win32

--- a/examples/CheckpointCutsEvent.hs
+++ b/examples/CheckpointCutsEvent.hs
@@ -1,0 +1,56 @@
+{-
+This example is mostly just to test that this bug is fixed:
+
+https://github.com/acid-state/acid-state/issues/73
+
+At the end of a run, the checkpoint file should contain a single
+checkpoint and the event file should be empty. The old checkpoints and
+events should be in the Archive directory.
+
+In the Acrhive directory, each checkpoint file should contain one
+checkpoint, and each event file should contain 10 events.
+
+If you comment out the 'createArchive' line below, then the checkpoint
+files should contain 10 checkpoints each.
+
+-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Main (main) where
+
+-- import           Control.Concurrent
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Data.Acid
+import           Data.SafeCopy
+import           Data.Typeable
+import           System.Environment
+
+------------------------------------------------------
+-- The Haskell structure that we want to encapsulate
+
+newtype Counter = Counter { unCounter :: Integer }
+    deriving (Show, Typeable)
+
+$(deriveSafeCopy 0 'base ''Counter)
+
+incCounter :: Update Counter Integer
+incCounter =
+  do (Counter c) <- get
+     let c' = succ c
+     put (Counter c')
+     return c'
+
+$(makeAcidic ''Counter ['incCounter])
+
+
+main :: IO ()
+main =
+  do acid <- openLocalState (Counter 0)
+     replicateM_ 10 $ do is <- replicateM 10 (update acid IncCounter)
+                         print is
+                         createCheckpoint acid
+                         createArchive acid
+     closeAcidState acid

--- a/src-unix/FileIO.hs
+++ b/src-unix/FileIO.hs
@@ -1,30 +1,16 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-module FileIO(FHandle,open,write,flush,close,obtainPrefixLock,releasePrefixLock,PrefixLock) where
+module FileIO(FHandle,open,write,flush,close) where
 import System.Posix(Fd(Fd),
                     openFd,
                     fdWriteBuf,
-                    fdToHandle,
                     closeFd,
-                    OpenMode(WriteOnly,ReadWrite),
-                    exclusive, trunc,
+                    OpenMode(WriteOnly),
                     defaultFileFlags,
                     stdFileMode
                    )
 import Data.Word(Word8,Word32)
 import Foreign(Ptr)
 import Foreign.C(CInt(..))
-import System.IO
-
-import Data.Maybe (listToMaybe)
-import qualified System.IO.Error as SE
-import System.Posix.Process (getProcessID)
-import System.Posix.Signals (nullSignal, signalProcess)
-import System.Posix.Types (ProcessID)
-import Control.Exception.Extensible as E
-import System.Directory         ( createDirectoryIfMissing, removeFile)
-import System.FilePath
-
-newtype PrefixLock = PrefixLock FilePath
 
 data FHandle = FHandle Fd
 
@@ -43,111 +29,3 @@ foreign import ccall "fsync" c_fsync :: CInt -> IO CInt
 
 close :: FHandle -> IO ()
 close (FHandle fd) = closeFd fd
-
--- Unix needs to use a special open call to open files for exclusive writing
---openExclusively :: FilePath -> IO Handle
---openExclusively fp =
---    fdToHandle =<< openFd fp ReadWrite (Just 0o600) flags
---    where flags = defaultFileFlags {exclusive = True, trunc = True}
-
-
-
-
-obtainPrefixLock :: FilePath -> IO PrefixLock
-obtainPrefixLock prefix = do
-    checkLock fp >> takeLock fp
-    where fp = prefix ++ ".lock"
-
--- |Read the lock and break it if the process is dead.
-checkLock :: FilePath -> IO ()
-checkLock fp = readLock fp >>= maybeBreakLock fp
-
--- |Read the lock and return the process id if possible.
-readLock :: FilePath -> IO (Maybe ProcessID)
-readLock fp = try (readFile fp) >>=
-              return . either (checkReadFileError fp) (fmap (fromInteger . read) . listToMaybe . lines)
-
--- |Is this a permission error?  If so we don't have permission to
--- remove the lock file, abort.
-checkReadFileError :: [Char] -> IOError -> Maybe ProcessID
-checkReadFileError fp e | SE.isPermissionError e = throw (userError ("Could not read lock file: " ++ show fp))
-                        | SE.isDoesNotExistError e = Nothing
-                        | True = throw e
-
-maybeBreakLock :: FilePath -> Maybe ProcessID -> IO ()
-maybeBreakLock fp Nothing =
-    -- The lock file exists, but there's no PID in it.  At this point,
-    -- we will break the lock, because the other process either died
-    -- or will give up when it failed to read its pid back from this
-    -- file.
-    breakLock fp
-maybeBreakLock fp (Just pid) = do
-  -- The lock file exists and there is a PID in it.  We can break the
-  -- lock if that process has died.
-  -- getProcessStatus only works on the children of the calling process.
-  -- exists <- try (getProcessStatus False True pid) >>= either checkException (return . isJust)
-  exists <- doesProcessExist pid
-  case exists of
-    True -> throw (lockedBy fp pid)
-    False -> breakLock fp
-
-doesProcessExist :: ProcessID -> IO Bool
-doesProcessExist pid =
-    -- Implementation 1
-    -- doesDirectoryExist ("/proc/" ++ show pid)
-    -- Implementation 2
-    try (signalProcess nullSignal pid) >>= return . either checkException (const True)
-    where checkException e | SE.isDoesNotExistError e = False
-                           | True = throw e
-
--- |We have determined the locking process is gone, try to remove the
--- lock.
-breakLock :: FilePath -> IO ()
-breakLock fp = try (removeFile fp) >>= either checkBreakError (const (return ()))
-
--- |An exception when we tried to break a lock, if it says the lock
--- file has already disappeared we are still good to go.
-checkBreakError :: IOError -> IO ()
-checkBreakError e | SE.isDoesNotExistError e = return ()
-                  | True = throw e
-
--- |Try to create lock by opening the file with the O_EXCL flag and
--- writing our PID into it.  Verify by reading the pid back out and
--- matching, maybe some other process slipped in before we were done
--- and broke our lock.
-takeLock :: FilePath -> IO PrefixLock
-takeLock fp = do
-  createDirectoryIfMissing True (takeDirectory fp)
-  h <- openFd fp ReadWrite (Just 0o600) (defaultFileFlags {exclusive = True, trunc = True}) >>= fdToHandle
-  pid <- getProcessID
-  hPutStrLn h (show pid) >> hClose h
-  -- Read back our own lock and make sure its still ours
-  readLock fp >>= maybe (throw (cantLock fp pid))
-                        (\ pid' -> if pid /= pid'
-                                   then throw (stolenLock fp pid pid')
-                                   else return (PrefixLock fp))
-
--- |An exception saying the data is locked by another process.
-lockedBy :: (Show a) => FilePath -> a -> SomeException
-lockedBy fp pid = SomeException (SE.mkIOError SE.alreadyInUseErrorType ("Locked by " ++ show pid) Nothing (Just fp))
-
--- |An exception saying we don't have permission to create lock.
-cantLock :: FilePath -> ProcessID -> SomeException
-cantLock fp pid = SomeException (SE.mkIOError SE.alreadyInUseErrorType ("Process " ++ show pid ++ " could not create a lock") Nothing (Just fp))
-
--- |An exception saying another process broke our lock before we
--- finished creating it.
-stolenLock :: FilePath -> ProcessID -> ProcessID -> SomeException
-stolenLock fp pid pid' = SomeException (SE.mkIOError SE.alreadyInUseErrorType ("Process " ++ show pid ++ "'s lock was stolen by process " ++ show pid') Nothing (Just fp))
-
--- |Relinquish the lock by removing it and then verifying the removal.
-releasePrefixLock :: PrefixLock -> IO ()
-releasePrefixLock (PrefixLock fp) =
-    dropLock >>= either checkDrop return
-    where
-      dropLock = try (removeFile fp)
-      checkDrop e | SE.isDoesNotExistError e = return ()
-                  | True = throw e
-
-
-

--- a/src/Data/Acid.hs
+++ b/src/Data/Acid.hs
@@ -9,7 +9,7 @@
  AcidState container using a transaction log on disk.
 
  To see how it all fits together, have a look at these example
- <http://mirror.seize.it/acid-state/examples/>.
+ <https://github.com/acid-state/acid-state/tree/master/examples>.
 
 -}
 

--- a/src/Data/Acid.hs
+++ b/src/Data/Acid.hs
@@ -30,6 +30,7 @@ module Data.Acid
     , Query
     , IsAcidic
     , makeAcidic
+    , makeAcidicWithHacks
     , liftQuery
     ) where
 

--- a/src/Data/Acid/Core.hs
+++ b/src/Data/Acid/Core.hs
@@ -46,12 +46,16 @@ import Data.ByteString.Lazy.Char8 as Lazy ( pack, unpack )
 import Data.Serialize                     ( runPutLazy, runGetLazy )
 import Data.SafeCopy                      ( SafeCopy, safeGet, safePut )
 
-import Data.Typeable                      ( Typeable, TypeRep, typeOf )
+import Data.Typeable                      ( Typeable, TypeRep, typeRepTyCon, typeOf )
 import Unsafe.Coerce                      ( unsafeCoerce )
 
-#if MIN_VERSION_base(4,4,0)
+#if MIN_VERSION_base(4,5,0)
+import Data.Typeable                      ( tyConModule )
+#else
+import Data.Typeable.Internal             ( tyConModule )
+#endif
 
-import Data.Typeable.Internal             ( TypeRep (..), tyConModule )
+#if MIN_VERSION_base(4,4,0)
 
 -- in base >= 4.4 the Show instance for TypeRep no longer provides a
 -- fully qualified name. But we have old data around that expects the
@@ -60,12 +64,7 @@ import Data.Typeable.Internal             ( TypeRep (..), tyConModule )
 -- end-of-life anyway.
 showQualifiedTypeRep :: TypeRep -> String
 showQualifiedTypeRep tr = tyConModule con ++ "." ++ show tr
-  where con = extractTypeRepCon tr
-#if MIN_VERSION_base(4,8,0)
-        extractTypeRepCon (TypeRep _ c _ _) = c
-#else
-        extractTypeRepCon (TypeRep _ c _) = c
-#endif
+  where con = typeRepTyCon tr
 
 #else
 

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -179,7 +179,8 @@ localQueryCold acidState event
 --   This call will not return until the operation has succeeded.
 createLocalCheckpoint :: SafeCopy st => LocalState st -> IO ()
 createLocalCheckpoint acidState
-    = do mvar <- newEmptyMVar
+    = do cutFileLog (localEvents acidState)
+         mvar <- newEmptyMVar
          withCoreState (localCore acidState) $ \st ->
            do eventId <- askCurrentEntryId (localEvents acidState)
               pushAction (localEvents acidState) $

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -42,8 +42,9 @@ import Data.SafeCopy                  ( SafeCopy(..), safeGet, safePut
                                       , primitive, contain )
 import Data.Typeable                  ( Typeable, typeOf )
 import Data.IORef
-import System.FilePath                ( (</>) )
+import System.FilePath                ( (</>), takeDirectory )
 import System.FileLock
+import System.Directory               ( createDirectoryIfMissing )
 
 
 {-| State container offering full ACID (Atomicity, Consistency, Isolation and Durability)
@@ -318,7 +319,9 @@ resumeLocalStateFrom directory initialState delayLocking =
                                       , localCheckpoints = checkpointsLog
                                       , localLock = lock
                                       }
-    maybeLockFile path = maybe (throwIO (StateIsLocked path))
+    maybeLockFile path = do
+      createDirectoryIfMissing True (takeDirectory path)
+      maybe (throwIO (StateIsLocked path))
                             pure =<< tryLockFile path Exclusive
 
 

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -30,13 +30,12 @@ import Data.Acid.Common
 import Data.Acid.Abstract
 
 import Control.Concurrent             ( newEmptyMVar, putMVar, takeMVar, MVar )
-import Control.Exception              ( onException, evaluate )
+import Control.Exception              ( onException, evaluate, Exception, throwIO )
 import Control.Monad.State            ( runState )
 import Control.Monad                  ( join )
 import Control.Applicative            ( (<$>), (<*>) )
 import Data.ByteString.Lazy           ( ByteString )
 import qualified Data.ByteString.Lazy as Lazy ( length )
-
 
 import Data.Serialize                 ( runPutLazy, runGetLazy )
 import Data.SafeCopy                  ( SafeCopy(..), safeGet, safePut
@@ -44,8 +43,7 @@ import Data.SafeCopy                  ( SafeCopy(..), safeGet, safePut
 import Data.Typeable                  ( Typeable, typeOf )
 import Data.IORef
 import System.FilePath                ( (</>) )
-
-import FileIO                         ( obtainPrefixLock, releasePrefixLock, PrefixLock )
+import System.FileLock
 
 
 {-| State container offering full ACID (Atomicity, Consistency, Isolation and Durability)
@@ -66,9 +64,12 @@ data LocalState st
                  , localCopy        :: IORef st
                  , localEvents      :: FileLog (Tagged ByteString)
                  , localCheckpoints :: FileLog Checkpoint
-                 , localLock        :: PrefixLock
+                 , localLock        :: FileLock
                  } deriving (Typeable)
 
+newtype StateIsLocked = StateIsLocked FilePath deriving (Show, Typeable)
+
+instance Exception StateIsLocked
 
 -- | Issue an Update event and return immediately. The event is not durable
 --   before the MVar has been filled but the order of events is honored.
@@ -201,7 +202,7 @@ createCheckpointAndClose abstract_state
          takeMVar mvar
          closeFileLog (localEvents acidState)
          closeFileLog (localCheckpoints acidState)
-         releasePrefixLock (localLock acidState)
+         unlockFile (localLock acidState)
   where acidState = downcast abstract_state
 
 
@@ -278,11 +279,11 @@ resumeLocalStateFrom directory initialState delayLocking =
     True -> do
       (n, st) <- loadCheckpoint
       return $ do
-        lock  <- obtainPrefixLock lockFile
+        lock  <- maybeLockFile lockFile
         replayEvents lock n st
     False -> do
-      lock    <- obtainPrefixLock lockFile
-      (n, st) <- loadCheckpoint `onException` releasePrefixLock lock
+      lock    <- maybeLockFile lockFile
+      (n, st) <- loadCheckpoint `onException` unlockFile lock
       return $ do
         replayEvents lock n st
   where
@@ -317,9 +318,13 @@ resumeLocalStateFrom directory initialState delayLocking =
                                       , localCheckpoints = checkpointsLog
                                       , localLock = lock
                                       }
+    maybeLockFile path = maybe (throwIO (StateIsLocked path))
+                            pure =<< tryLockFile path Exclusive
+
 
 checkpointRestoreError msg
     = error $ "Could not parse saved checkpoint due to the following error: " ++ msg
+
 
 -- | Close an AcidState and associated logs.
 --   Any subsequent usage of the AcidState will throw an exception.
@@ -328,7 +333,7 @@ closeLocalState acidState
     = do closeCore (localCore acidState)
          closeFileLog (localEvents acidState)
          closeFileLog (localCheckpoints acidState)
-         releasePrefixLock (localLock acidState)
+         unlockFile (localLock acidState)
 
 createLocalArchive :: LocalState st -> IO ()
 createLocalArchive state
@@ -361,4 +366,3 @@ toAcidState local
               , closeAcidState = closeLocalState local
               , acidSubState = mkAnyState local
               }
-

--- a/src/Data/Acid/Local.hs
+++ b/src/Data/Acid/Local.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable, BangPatterns, CPP, ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns, CPP, DeriveDataTypeable, OverloadedStrings,
+             ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Acid.Local
@@ -25,28 +26,27 @@ module Data.Acid.Local
     , Checkpoint(..)
     ) where
 
-import Data.Acid.Log as Log
-import Data.Acid.Core
-import Data.Acid.Common
 import Data.Acid.Abstract
+import Data.Acid.Common
+import Data.Acid.Core
+import Data.Acid.Log as Log
 
-import Control.Concurrent             ( newEmptyMVar, putMVar, takeMVar, MVar )
-import Control.Exception              ( onException, evaluate, Exception, throwIO )
-import Control.Monad.State            ( runState )
-import Control.Monad                  ( join )
-import Control.Applicative            ( (<$>), (<*>) )
-import Data.ByteString.Lazy           ( ByteString )
-import qualified Data.ByteString.Lazy as Lazy ( length )
+import Control.Applicative ((<$>), (<*>))
+import Control.Concurrent (MVar, newEmptyMVar, putMVar, takeMVar)
+import Control.Exception (Exception, evaluate, onException, throwIO)
+import Control.Monad (join)
+import Control.Monad.State (runState)
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as Lazy (length)
 
-import Data.Serialize                 ( runPutLazy, runGetLazy )
-import Data.SafeCopy                  ( SafeCopy(..), safeGet, safePut
-                                      , primitive, contain )
-import Data.Typeable                  ( Typeable, typeOf )
-import Data.IORef
 import Data.Either
-import System.FilePath                ( (</>), takeDirectory )
+import Data.IORef
+import Data.SafeCopy (SafeCopy(..), contain, primitive, safeGet, safePut)
+import Data.Serialize (runGetLazy, runPutLazy)
+import Data.Typeable (Typeable, typeOf)
+import System.Directory (createDirectoryIfMissing)
 import System.FileLock
-import System.Directory               ( createDirectoryIfMissing )
+import System.FilePath (takeDirectory, (</>))
 
 
 {-| State container offering full ACID (Atomicity, Consistency, Isolation and Durability)
@@ -327,11 +327,14 @@ getState directory initialState pos delayLocking =
       eventsLog <- openFileLog eventsLogKey
       events <- readEntriesFrom eventsLog n
       let numberOfEvents = length events
-      if num < numberOfEvents
+      if num <= numberOfEvents
       then do
-        let requestedEvents = take (numberOfEvents - num - 1) events
+        let requestedEvents = take (numberOfEvents - num) events
         mapM_ (runColdMethod core) requestedEvents
-        let (lastMethod,_) = last requestedEvents
+        let lastMethod =
+              if null requestedEvents
+              then "This is the initial state. No methods were applied to the DB."
+              else fst $ last requestedEvents
         ensureLeastEntryId eventsLog n
         checkpointsLog <- openFileLog checkpointsLogKey
         stateCopy <- newIORef undefined

--- a/src/Data/Acid/Log.hs
+++ b/src/Data/Acid/Log.hs
@@ -262,7 +262,7 @@ archiveFileLog fLog entryId = do
   logFiles <- findLogFiles (logIdentifier fLog)
   let sorted = sort logFiles
       relevant = filterLogFiles Nothing (Just entryId) sorted \\
-                 filterLogFiles (Just (entryId+1)) (Just entryId) sorted
+                 filterLogFiles (Just entryId) (Just (entryId+1))  sorted
 
   createDirectoryIfMissing True archiveDir
   forM_ relevant $ \(_startEntry, logFilePath) ->

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -226,7 +226,9 @@ makeEventHandler eventName eventType
 --  deriving (Typeable)
 makeEventDataType eventName eventType
     = do let con = normalC eventStructName [ strictType notStrict (return arg) | arg <- args ]
-#if MIN_VERSION_template_haskell(2,11,0)
+#if MIN_VERSION_template_haskell(2,12,0)
+             cxt = [derivClause Nothing [conT ''Typeable]]
+#elif MIN_VERSION_template_haskell(2,11,0)
              cxt = mapM conT [''Typeable]
 #else
              cxt = [''Typeable]

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -102,7 +102,7 @@ getEventType eventName
 #else
            VarI _name eventType _decl _fixity
 #endif
-             -> expandSyns eventType
+             -> expandSynsWith noWarnTypeFamilies eventType
            _ -> error $ "Events must be functions: " ++ show eventName
 
 --instance (SafeCopy key, Typeable key, SafeCopy val, Typeable val) => IsAcidic State where

--- a/src/Data/Acid/TemplateHaskell.hs
+++ b/src/Data/Acid/TemplateHaskell.hs
@@ -6,17 +6,20 @@ module Data.Acid.TemplateHaskell
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Ppr
+import Language.Haskell.TH.ExpandSyns
 
 import Data.Acid.Core
 import Data.Acid.Common
 
-import Data.List ((\\), nub)
+import Data.List ((\\), nub, delete)
 import Data.Maybe (mapMaybe)
 import Data.SafeCopy
 import Data.Typeable
 import Data.Char
 import Control.Applicative
 import Control.Monad
+import Control.Monad.State (MonadState)
+import Control.Monad.Reader (MonadReader)
 
 {-| Create the control structures required for acid states
     using Template Haskell.
@@ -89,7 +92,7 @@ getEventType eventName
 #else
            VarI _name eventType _decl _fixity
 #endif
-             -> return eventType
+             -> expandSyns eventType
            _ -> error $ "Events must be functions: " ++ show eventName
 
 --instance (SafeCopy key, Typeable key, SafeCopy val, Typeable val) => IsAcidic State where
@@ -140,7 +143,15 @@ makeIsAcidic eventNames stateName tyvars constructors
 -- need to rename the variables in the context to match.
 --
 -- The contexts returned by this function will have the variables renamed.
-eventCxts :: Type        -- ^ State type (used for error messages)
+--
+-- Additionally, if the event uses MonadReader or MonadState it might look
+-- like this:
+--
+-- > setState :: (MonadState x m, IsFoo x) => m ()
+--
+-- In this case we have to rename 'x' to the actual state we're going to
+-- use. This is done by 'renameState'.
+eventCxts :: Type        -- ^ State type
           -> [TyVarBndr] -- ^ type variables that will be used for the State type in the IsAcidic instance
           -> Name        -- ^ 'Name' of the event
           -> Type        -- ^ 'Type' of the event
@@ -148,9 +159,13 @@ eventCxts :: Type        -- ^ State type (used for error messages)
 eventCxts targetStateType targetTyVars eventName eventType =
     let (_tyvars, cxt, _args, stateType, _resultType, _isUpdate)
                     = analyseType eventName eventType
-        eventTyVars = findTyVars stateType -- find the type variable names that this event is using for the State type
-        table       = zip eventTyVars (map tyVarBndrName targetTyVars) -- create a lookup table
-    in map (unify table) cxt -- rename the type variables
+        -- find the type variable names that this event is using
+        -- for the State type
+        eventTyVars = findTyVars stateType
+        -- create a lookup table
+        table       = zip eventTyVars (map tyVarBndrName targetTyVars)
+    in map (unify table) -- rename the type variables
+       (renameState stateType targetStateType cxt)
     where
       -- | rename the type variables in a Pred
       unify :: [(Name, Name)] -> Pred -> Pred
@@ -190,6 +205,21 @@ eventCxts targetStateType targetTyVars eventName eventType =
                                        , "You may be able to fix this by providing a type signature that fixes these type variable(s)"
                                        ]
             (Just n') -> n'
+
+-- | See the end of comment for 'eventCxts'.
+renameState :: Type -> Type -> Cxt -> Cxt
+renameState tfrom tto cxt = map renamePred cxt
+  where
+#if MIN_VERSION_template_haskell(2,10,0)
+    renamePred p = renameType p -- in 2.10.0: type Pred = Type
+#else
+    renamePred (ClassP n tys) = ClassP n (map renameType tys)
+    renamePred (EqualP a b)   = EqualP (renameType a) (renameType b)
+#endif
+    renameType n | n == tfrom = tto
+    renameType (AppT a b)     = AppT (renameType a) (renameType b)
+    renameType (SigT a k)     = SigT (renameType a) k
+    renameType typ            = typ
 
 -- UpdateEvent (\(MyUpdateEvent arg1 arg2) -> myUpdateEvent arg1 arg2)
 makeEventHandler :: Name -> Type -> ExpQ
@@ -316,26 +346,44 @@ makeEventInstance eventName eventType
 
 -- (tyvars, cxt, args, state type, result type, is update)
 analyseType :: Name -> Type -> ([TyVarBndr], Cxt, [Type], Type, Type, Bool)
-analyseType eventName t
-    = let (tyvars, cxt, t') = case t of
-                                ForallT binds [] t' ->
-                                  (binds, [], t')
-                                ForallT binds cxt t' ->
-                                  (binds, cxt, t')
-                                _ -> ([], [], t)
-          args = getArgs t'
-          (stateType, resultType, isUpdate) = findMonad t'
-      in (tyvars, cxt, args, stateType, resultType, isUpdate)
-    where getArgs ForallT{} = error $ "Event has an invalid type signature: Nested forall: " ++ show eventName
-          getArgs (AppT (AppT ArrowT a) b) = a : getArgs b
-          getArgs _ = []
+analyseType eventName t = go [] [] [] t
+  where
+    getMonadReader :: Cxt -> Name -> [(Type, Type)]
+    getMonadReader cxt m = do
+       constraint@(AppT (AppT (ConT c) x) m') <- cxt
+       guard (c == ''MonadReader && m' == VarT m)
+       return (constraint, x)
 
-          findMonad (AppT (AppT ArrowT a) b)
-              = findMonad b
-          findMonad (AppT (AppT (ConT con) state) result)
-              | con == ''Update = (state, result, True)
-              | con == ''Query  = (state, result, False)
-          findMonad _ = error $ "Event has an invalid type signature: Not an Update or a Query: " ++ show eventName
+    getMonadState :: Cxt -> Name -> [(Type, Type)]
+    getMonadState cxt m = do
+       constraint@(AppT (AppT (ConT c) x) m') <- cxt
+       guard (c == ''MonadState && m' == VarT m)
+       return (constraint, x)
+
+    -- a -> b
+    go tyvars cxt args (AppT (AppT ArrowT a) b)
+        = go tyvars cxt (args ++ [a]) b
+    -- Update st res
+    -- Query st res
+    go tyvars cxt args (AppT (AppT (ConT con) state) result)
+        | con == ''Update = (tyvars, cxt, args, state, result, True)
+        | con == ''Query  = (tyvars, cxt, args, state, result, False)
+    -- (...) => a
+    go tyvars cxt args (ForallT tyvars2 cxt2 a)
+        = go (tyvars ++ tyvars2) (cxt ++ cxt2) args a
+    -- (MonadState state m) => ... -> m result
+    -- (MonadReader state m) => ... -> m result
+    go tyvars cxt args (AppT (VarT m) result)
+        | [] <- queries, [(cx, state)] <- updates
+            = (tyvars', delete cx cxt, args, state, result, True)
+        | [(cx, state)] <- queries, [] <- updates
+            = (tyvars', delete cx cxt, args, state, result, False)
+      where
+        queries = getMonadReader cxt m
+        updates = getMonadState cxt m
+        tyvars' = filter ((/= m) . tyVarBndrName) tyvars
+    -- otherwise, fail
+    go _ _ _ _ = error $ "Event has an invalid type signature: Not an Update, Query, MonadState, or MonadReader: " ++ show eventName
 
 -- | find the type variables
 -- | e.g. State a b  ==> [a,b]

--- a/src/Serokell/AcidState/ExtendedState.hs
+++ b/src/Serokell/AcidState/ExtendedState.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE TypeFamilies #-}
+
+-- | The idea of ExtendedState is to store information about location
+-- of the state (either FilePath or memory).
+
+module Serokell.AcidState.ExtendedState
+       ( ExtendedState (..)
+       , closeExtendedState
+       , extendedStateToAcid
+       , openLocalExtendedState
+       , openMemoryExtendedState
+       , queryExtended
+       , tidyExtendedState
+       , updateExtended
+       ) where
+
+import           Control.Monad.Extra     (whenM)
+import           Control.Monad.Trans     (MonadIO (liftIO))
+import           Data.Acid               (AcidState, EventResult, EventState, IsAcidic,
+                                          QueryEvent, UpdateEvent, closeAcidState,
+                                          openLocalStateFrom)
+import           Data.Acid.Advanced      (query', update')
+import           Data.Acid.Memory        (openMemoryState)
+import           Data.Typeable           (Typeable)
+
+import           System.Directory        (doesDirectoryExist, removeDirectoryRecursive)
+
+import           Serokell.AcidState.Util (tidyLocalState)
+
+-- | ExtendedState is like usual AcidState, but also stores
+-- information about FilePath (unless it's in memory).
+data ExtendedState st
+    = ESLocal (AcidState st)
+              FilePath
+    | ESMemory (AcidState st)
+
+-- | Convert ExtendedState to AcidState.
+extendedStateToAcid :: ExtendedState st -> AcidState st
+extendedStateToAcid (ESLocal s _) = s
+extendedStateToAcid (ESMemory s)  = s
+
+-- | Like query', but works on ExtendedState.
+queryExtended
+    :: (EventState event ~ st, QueryEvent event, MonadIO m)
+    => ExtendedState st -> event -> m (EventResult event)
+queryExtended st = query' (extendedStateToAcid st)
+
+-- | Like update', but works on ExtendedState.
+updateExtended
+    :: (EventState event ~ st, UpdateEvent event, MonadIO m)
+    => ExtendedState st -> event -> m (EventResult event)
+updateExtended st = update' (extendedStateToAcid st)
+
+-- | Like openLocalStateFrom, but returns ExtendedState and operates
+-- in MonadIO.
+openLocalExtendedState
+    :: (IsAcidic st, Typeable st, MonadIO m)
+    => Bool -> FilePath -> st -> m (ExtendedState st)
+openLocalExtendedState deleteIfExists fp st = do
+    whenM ((deleteIfExists &&) <$> liftIO (doesDirectoryExist fp)) $
+        liftIO $ removeDirectoryRecursive fp
+    liftIO $ flip ESLocal fp <$> openLocalStateFrom fp st
+
+-- | Like openMemoryState, but returns ExtendedState and operates in
+-- MonadIO.
+openMemoryExtendedState
+    :: (IsAcidic st, Typeable st, MonadIO m)
+    => st -> m (ExtendedState st)
+openMemoryExtendedState st = liftIO $ ESMemory <$> openMemoryState st
+
+-- | Like closeAcidState, but operates on ExtendedState and in
+-- MonadIO.
+closeExtendedState :: MonadIO m => ExtendedState st -> m ()
+closeExtendedState = liftIO . closeAcidState . extendedStateToAcid
+
+-- | Like tidyLocalState, but operates on ExtendedState.
+tidyExtendedState :: MonadIO m => ExtendedState st -> m ()
+tidyExtendedState (ESLocal st fp) = tidyLocalState st fp
+tidyExtendedState (ESMemory _)    = return ()

--- a/src/Serokell/AcidState/Instances.hs
+++ b/src/Serokell/AcidState/Instances.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE CPP #-}
+
+-- | Helper instances for acid-state to remove boilerplate and introduce
+-- redundant instances for other data types.
+
+module Serokell.AcidState.Instances where
+
+import           Control.Exception   (throw)
+import           Control.Monad.Catch (MonadThrow (throwM))
+
+import qualified Data.Time.Units     as Time
+import           Data.Acid           (Query, Update)
+import           Data.Hashable       (Hashable)
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HM hiding (HashMap)
+import           Data.HashSet        (HashSet)
+import qualified Data.HashSet        as HS hiding (HashSet)
+import           Data.SafeCopy       (SafeCopy (..), contain, safeGet,
+                                      safePut)
+
+#if !MIN_VERSION_safecopy(0,9,3)
+import qualified Data.List.NonEmpty  as NE
+#endif
+
+instance MonadThrow (Update s) where
+    throwM = throw
+
+instance (Eq a, Hashable a, SafeCopy a) => SafeCopy (HashSet a) where
+    putCopy = contain . safePut . HS.toList
+    getCopy = contain $ HS.fromList <$> safeGet
+
+instance (Eq a, Hashable a, SafeCopy a, SafeCopy b) => SafeCopy (HashMap a b) where
+    putCopy = contain . safePut . HM.toList
+    getCopy = contain $ HM.fromList <$> safeGet
+
+#if !MIN_VERSION_safecopy(0,9,3)
+instance SafeCopy a => SafeCopy (NE.NonEmpty a) where
+    getCopy = contain $ do
+        xs <- safeGet
+        case NE.nonEmpty xs of
+            Nothing -> fail "getCopy@NonEmpty: list can't be empty"
+            Just xx -> return xx
+    putCopy = contain . safePut . NE.toList
+    errorTypeName _ = "NonEmpty"
+#endif
+
+#define SAFECOPY_TIME(T, TS)                     \
+  instance SafeCopy T where {                    \
+    getCopy = contain (fromInteger <$> safeGet); \
+    putCopy = contain . safePut . toInteger;     \
+    errorTypeName _ = TS }                       \
+
+SAFECOPY_TIME(Time.Fortnight, "Fortnight")
+SAFECOPY_TIME(Time.Week, "Week")
+SAFECOPY_TIME(Time.Day, "Day")
+SAFECOPY_TIME(Time.Hour, "Hour")
+SAFECOPY_TIME(Time.Minute, "Minute")
+SAFECOPY_TIME(Time.Second, "Second")
+SAFECOPY_TIME(Time.Millisecond, "Millisecond")
+SAFECOPY_TIME(Time.Microsecond, "Microsecond")
+SAFECOPY_TIME(Time.Nanosecond, "Nanosecond")
+SAFECOPY_TIME(Time.Picosecond, "Picosecond")
+SAFECOPY_TIME(Time.Femtosecond, "Femtosecond")
+SAFECOPY_TIME(Time.Attosecond, "Attosecond")
+
+#undef SAFECOPY_TIME

--- a/src/Serokell/AcidState/Util.hs
+++ b/src/Serokell/AcidState/Util.hs
@@ -1,0 +1,56 @@
+-- | Some useful functions to work with Data.Acid.
+
+module Serokell.AcidState.Util
+       (
+         -- | Simple helpers
+         exceptStateToUpdate
+       , exceptStateToUpdateGeneric
+       , readerToQuery
+       , stateToUpdate
+
+         -- | Utilities
+       , createAndDiscardArchive
+       , tidyLocalState
+       ) where
+
+import           Control.Exception    (Exception, throw)
+import           Control.Monad.Except (ExceptT, runExceptT)
+import           Control.Monad.Reader (Reader, asks, runReader)
+import           Control.Monad.State  (State, runState, state)
+import           Control.Monad.Trans  (MonadIO (liftIO))
+import           Data.Acid            (AcidState, Query, Update, createArchive,
+                                       createCheckpoint)
+import           System.Directory     (removeDirectoryRecursive)
+import           System.FilePath      ((</>))
+
+readerToQuery :: Reader s a -> Query s a
+readerToQuery = asks . runReader
+
+stateToUpdate :: State s a -> Update s a
+stateToUpdate = state . runState
+
+exceptStateToUpdate
+    :: (Exception e)
+    => ExceptT e (State s) a -> Update s a
+exceptStateToUpdate = exceptStateToUpdateGeneric id
+
+exceptStateToUpdateGeneric
+  :: (Exception exc)
+  => (e -> exc) -> ExceptT e (State s) a -> Update s a
+exceptStateToUpdateGeneric toException u =
+    state $
+    runState $
+    do res <- runExceptT u
+       either (throw . toException) return res
+
+-- | Archive unnecessary data (see createArchive docs for details) and
+-- discard it. Works for local state.
+createAndDiscardArchive :: MonadIO m => AcidState st -> FilePath -> m ()
+createAndDiscardArchive st path =
+    liftIO $ createArchive st >> removeDirectoryRecursive (path </> "Archive")
+
+-- | Apply all updates and remove all data from local state which is
+-- unnecessary for state restoration.
+tidyLocalState :: MonadIO m => AcidState st -> FilePath -> m ()
+tidyLocalState st path =
+    liftIO (createCheckpoint st) >> createAndDiscardArchive st path

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-9.21
+packages: [.]
+
+extra-deps:
+- time-units-1.0.0


### PR DESCRIPTION
Fixed `getState` function, there were 2 bugs added in the previous commit: 

1) In case of an empty DB it fails, because there is no previous event.

2) getState returned not the current state but the state one event ago. 

Fixed both. 